### PR TITLE
Exclude Embed Gist JS from Autoptimize

### DIFF
--- a/classes/class-wp-gist.php
+++ b/classes/class-wp-gist.php
@@ -177,6 +177,13 @@ class WP_Gist {
 
         } // end if
 
+        // Check if Autoptimize is activate & optimizing JS code & not look for scripts in <head> only
+        if ( class_exists( 'autoptimizeCache' ) && get_option( 'autoptimize_js', false ) && ! get_option( 'autoptimize_js_justhead', false ) ) {
+
+            return '<!--noptimize--><script src="' . $url . '"></script><!--/noptimize-->';
+
+        } // end if
+
         // Construct Gist script and return.
         return '<script src="' . $url . '"></script>';
 


### PR DESCRIPTION
Autoptimize puts JS scripts at the footer. The pull request exclude the embed gist JS from Autoptimize.
Link to Autoptimize plugin http://wordpress.org/plugins/autoptimize/

Update on 15 Aug 2014: 
Now using `<!--noptimize-->` tag instead of Options API.
